### PR TITLE
Sshirokov/v2 single tx copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ For complete usage examples, please refer to <https://github.com/OpenCyphal-Gara
 
 ## Revisions
 
+### TODO: Add new v2
+☝ todo will be addressed as soon as the new API is stable.
+
 ### v1.0
 
 Initial release.

--- a/libudpard/udpard.c
+++ b/libudpard/udpard.c
@@ -654,15 +654,10 @@ struct UdpardTxItem* udpardTxPeek(const struct UdpardTx* const self)
     return out;
 }
 
-struct UdpardTxItem* udpardTxPop(struct UdpardTx* const self, const struct UdpardTxItem* const item)
+struct UdpardTxItem* udpardTxPop(struct UdpardTx* const self, struct UdpardTxItem* const item)
 {
-    struct UdpardTxItem* out = NULL;
     if ((self != NULL) && (item != NULL))
     {
-        // Intentional violation of MISRA: casting away const qualifier. This is considered safe because the API
-        // contract dictates that the pointer shall point to a mutable entity in RAM previously allocated by the
-        // memory manager. It is difficult to avoid this cast in this context.
-        out = (struct UdpardTxItem*) item;  // NOSONAR casting away const qualifier.
         // Paragraph 6.7.2.1.15 of the C standard says:
         //     A pointer to a structure object, suitably converted, points to its initial member, and vice versa.
         // Note that the highest-priority frame is always a leaf node in the AVL tree, which means that it is very
@@ -671,7 +666,7 @@ struct UdpardTxItem* udpardTxPop(struct UdpardTx* const self, const struct Udpar
         UDPARD_ASSERT(self->queue_size > 0U);
         self->queue_size--;
     }
-    return out;
+    return item;
 }
 
 void udpardTxFree(const struct UdpardTxMemoryResources memory, struct UdpardTxItem* const item)

--- a/libudpard/udpard.c
+++ b/libudpard/udpard.c
@@ -404,13 +404,13 @@ static inline byte_t* txSerializeHeader(byte_t* const          destination_buffe
 /// Produces a chain of Tx queue items for later insertion into the Tx queue. The tail is NULL if OOM.
 /// The caller is responsible for freeing the memory allocated for the chain.
 static inline TxChain txMakeChain(const struct UdpardTxMemoryResources memory,
-                                  const uint_least8_t                  dscp_value_per_priority[UDPARD_PRIORITY_MAX + 1U],
-                                  const size_t                         mtu,
-                                  const UdpardMicrosecond              deadline_usec,
-                                  const TransferMetadata               meta,
-                                  const struct UdpardUDPIPEndpoint     endpoint,
-                                  const struct UdpardPayload           payload,
-                                  void* const                          user_transfer_reference)
+                                  const uint_least8_t              dscp_value_per_priority[UDPARD_PRIORITY_MAX + 1U],
+                                  const size_t                     mtu,
+                                  const UdpardMicrosecond          deadline_usec,
+                                  const TransferMetadata           meta,
+                                  const struct UdpardUDPIPEndpoint endpoint,
+                                  const struct UdpardPayload       payload,
+                                  void* const                      user_transfer_reference)
 {
     UDPARD_ASSERT(mtu > 0);
     UDPARD_ASSERT((payload.data != NULL) || (payload.size == 0U));
@@ -443,9 +443,9 @@ static inline TxChain txMakeChain(const struct UdpardTxMemoryResources memory,
         {
             break;
         }
-        const bool last          = (payload_size_with_crc - offset) <= mtu;
+        const bool    last       = (payload_size_with_crc - offset) <= mtu;
         byte_t* const dst_buffer = item->base.datagram_payload.data;
-        byte_t* write_ptr        = txSerializeHeader(dst_buffer, meta, (uint32_t) out.count, last);
+        byte_t*       write_ptr  = txSerializeHeader(dst_buffer, meta, (uint32_t) out.count, last);
         if (offset < payload.size)
         {
             const size_t progress = smaller(payload.size - offset, mtu);

--- a/libudpard/udpard.h
+++ b/libudpard/udpard.h
@@ -373,6 +373,28 @@ struct UdpardMemoryResource
 // =================================================    TX PIPELINE    =================================================
 // =====================================================================================================================
 
+/// The set of memory resources is used per an TX pipeline instance.
+/// These are used to serve the memory needs of the library to keep state while assembling outgoing frames.
+/// Several memory resources are provided to enable fine control over the allocated memory.
+///
+/// This TX queue uses these memory resources for allocating the enqueued items (UDP datagrams).
+/// There are exactly two allocations per enqueued item:
+/// - the first for bookkeeping purposes (UdpardTxItem)
+/// - second for payload storage (the frame data)
+/// In a simple application, there would be just one memory resource shared by all parts of the library.
+/// If the application knows its MTU, it can use block allocation to avoid extrinsic fragmentation.
+///
+struct UdpardTxMemoryResources
+{
+    /// The fragment handles are allocated per payload fragment; each handle contains a pointer to its fragment.
+    /// Each instance is of a very small fixed size, so a trivial zero-fragmentation block allocator is enough.
+    struct UdpardMemoryResource fragment;
+
+    /// The payload fragments are allocated per payload frame; each payload fragment is at most MTU-sized buffer,
+    /// so a trivial zero-fragmentation MTU-sized block allocator is enough if MTU is known in advance.
+    struct UdpardMemoryResource payload;
+};
+
 /// The transmission pipeline is a prioritized transmission queue that keeps UDP datagrams (aka transport frames)
 /// destined for transmission via one network interface.
 /// Applications with redundant network interfaces are expected to have one instance of this type per interface.
@@ -424,12 +446,8 @@ struct UdpardTx
     /// The value can be changed arbitrarily at any time between enqueue operations.
     uint_least8_t dscp_value_per_priority[UDPARD_PRIORITY_MAX + 1U];
 
-    /// The memory resource used by this queue for allocating the enqueued items (UDP datagrams).
-    /// There is exactly one allocation per enqueued item, each allocation contains both the UdpardTxItem
-    /// and its payload, hence the size is variable.
-    /// In a simple application there would be just one memory resource shared by all parts of the library.
-    /// If the application knows its MTU, it can use block allocation to avoid extrinsic fragmentation.
-    struct UdpardMemoryResource memory;
+    /// Refer to UdpardTxMemoryResources.
+    struct UdpardTxMemoryResources memory;
 
     /// The number of frames that are currently contained in the queue, initially zero.
     /// READ-ONLY
@@ -490,10 +508,10 @@ struct UdpardTxItem
 ///
 /// The return value is zero on success, otherwise it is a negative error code.
 /// The time complexity is constant. This function does not invoke the dynamic memory manager.
-int_fast8_t udpardTxInit(struct UdpardTx* const            self,
-                         const UdpardNodeID* const         local_node_id,
-                         const size_t                      queue_capacity,
-                         const struct UdpardMemoryResource memory);
+int_fast8_t udpardTxInit(struct UdpardTx* const               self,
+                         const UdpardNodeID* const            local_node_id,
+                         const size_t                         queue_capacity,
+                         const struct UdpardTxMemoryResources memory);
 
 /// This function serializes a message transfer into a sequence of UDP datagrams and inserts them into the prioritized
 /// transmission queue at the appropriate position. Afterwards, the application is supposed to take the enqueued frames
@@ -613,23 +631,20 @@ int32_t udpardTxRespond(struct UdpardTx* const     self,
 ///
 /// If the queue is non-empty, the returned value is a pointer to its top element (i.e., the next item to transmit).
 /// The returned pointer points to an object allocated in the dynamic storage; it should be eventually freed by the
-/// application by calling udpardTxFree with UdpardTx::memory. The memory shall not be freed before the item is removed
+/// application by calling `udpardTxFree`. The memory shall not be freed before the item is removed
 /// from the queue by calling udpardTxPop; this is because until udpardTxPop is executed, the library retains
 /// ownership of the item. The pointer retains validity until explicitly freed by the application; in other words,
 /// calling udpardTxPop does not invalidate the object.
 ///
-/// The payload buffer is located shortly after the object itself, in the same memory fragment. The application shall
-/// not attempt to free it.
-///
 /// Calling functions that modify the queue may cause the next invocation to return a different pointer.
 ///
 /// The time complexity is logarithmic of the queue size. This function does not invoke the dynamic memory manager.
-const struct UdpardTxItem* udpardTxPeek(const struct UdpardTx* const self);
+struct UdpardTxItem* udpardTxPeek(const struct UdpardTx* const self);
 
 /// This function transfers the ownership of the specified item of the prioritized transmission queue from the queue
 /// to the application. The item does not necessarily need to be the top one -- it is safe to dequeue any item.
 /// The item is dequeued but not invalidated; it is the responsibility of the application to deallocate its memory
-/// later. The memory SHALL NOT be deallocated UNTIL this function is invoked.
+/// later. The memory SHALL NOT be deallocated UNTIL this function is invoked (use `udpardTxFree` helper).
 /// The function returns the same pointer that it is given except that it becomes mutable.
 ///
 /// If any of the arguments are NULL, the function has no effect and returns NULL.
@@ -637,11 +652,12 @@ const struct UdpardTxItem* udpardTxPeek(const struct UdpardTx* const self);
 /// The time complexity is logarithmic of the queue size. This function does not invoke the dynamic memory manager.
 struct UdpardTxItem* udpardTxPop(struct UdpardTx* const self, const struct UdpardTxItem* const item);
 
-/// This is a simple helper that frees the memory allocated for the item with the correct size.
-/// It is needed because the application does not have access to the required context to compute the size.
-/// If the chosen allocator does not leverage the size information, the deallocation function can be invoked directly.
+/// This is a simple helper that frees the memory allocated for the item and its payload,
+/// using the correct sizes and memory resources.
 /// If the item argument is NULL, the function has no effect. The time complexity is constant.
-void udpardTxFree(const struct UdpardMemoryResource memory, struct UdpardTxItem* const item);
+/// If the item frame payload is NULL then it is assumed that the payload buffer was already freed,
+/// or moved to a different owner (f.e. to media layer).
+void udpardTxFree(const struct UdpardTxMemoryResources memory, struct UdpardTxItem* const item);
 
 // =====================================================================================================================
 // =================================================    RX PIPELINE    =================================================

--- a/libudpard/udpard.h
+++ b/libudpard/udpard.h
@@ -173,7 +173,7 @@
 ///
 /// Typically, if block pool allocators are used, the following block sizes should be served:
 ///
-///     - (MTU+library overhead) blocks for the TX and RX pipelines (usually less than 2048 bytes);
+///     - MTU sized blocks for the TX and RX pipelines (usually less than 2048 bytes);
 ///     - TX fragment item sized blocks for the TX pipeline (less than 128 bytes).
 ///     - RX session object sized blocks for the RX pipeline (less than 512 bytes);
 ///     - RX fragment handle sized blocks for the RX pipeline (less than 128 bytes).
@@ -201,7 +201,7 @@ extern "C" {
 
 /// Semantic version of this library (not the Cyphal specification).
 /// API will be backward compatible within the same major version.
-#define UDPARD_VERSION_MAJOR 1
+#define UDPARD_VERSION_MAJOR 2
 #define UDPARD_VERSION_MINOR 0
 
 /// The version number of the Cyphal specification implemented by this library.
@@ -460,7 +460,7 @@ struct UdpardTx
 /// One transport frame (UDP datagram) stored in the UdpardTx transmission queue along with its metadata.
 /// The datagram should be sent to the indicated UDP/IP endpoint with the specified DSCP value.
 /// The datagram should be discarded (transmission aborted) if the deadline has expired.
-/// All fields are READ-ONLY except mutable payload `datagram_payload` field, which could be nullified to indicate
+/// All fields are READ-ONLY except the mutable `datagram_payload` field, which could be nullified to indicate
 /// a transfer of the payload memory ownership to somewhere else.
 ///
 struct UdpardTxItem
@@ -483,7 +483,7 @@ struct UdpardTxItem
     /// LibUDPard selects the DSCP value based on the transfer priority level and the configured DSCP mapping.
     uint_least8_t dscp;
 
-    /// Holds original transfer priority level (before DSCP mapping, see above `dscp`).
+    /// Holds the original transfer priority level (before DSCP mapping, see above `dscp`).
     enum UdpardPriority priority;
 
     /// This UDP/IP datagram compiled by libudpard should be sent to this endpoint.

--- a/libudpard/udpard.h
+++ b/libudpard/udpard.h
@@ -669,7 +669,7 @@ struct UdpardTxItem* udpardTxPeek(const struct UdpardTx* const self);
 /// If any of the arguments are NULL, the function has no effect and returns NULL.
 ///
 /// The time complexity is logarithmic of the queue size. This function does not invoke the dynamic memory manager.
-struct UdpardTxItem* udpardTxPop(struct UdpardTx* const self, const struct UdpardTxItem* const item);
+struct UdpardTxItem* udpardTxPop(struct UdpardTx* const self, struct UdpardTxItem* const item);
 
 /// This is a simple helper that frees the memory allocated for the item and its payload,
 /// using the correct sizes and memory resources.

--- a/libudpard/udpard.h
+++ b/libudpard/udpard.h
@@ -482,6 +482,9 @@ struct UdpardTxItem
     /// LibUDPard selects the DSCP value based on the transfer priority level and the configured DSCP mapping.
     uint_least8_t dscp;
 
+    /// Holds original transfer priority level (before DSCP mapping, see above `dscp`).
+    enum UdpardPriority priority;
+
     /// This UDP/IP datagram compiled by libudpard should be sent to this endpoint.
     /// The endpoint is always at a multicast address.
     struct UdpardUDPIPEndpoint destination;

--- a/tests/src/test_e2e.cpp
+++ b/tests/src/test_e2e.cpp
@@ -75,7 +75,7 @@ void testPubSub()
     instrumentedAllocatorNew(&alloc_rx_payload);
     const UdpardTxMemoryResources mem_tx{
         .fragment = instrumentedAllocatorMakeMemoryResource(&alloc_tx),
-        .payload = instrumentedAllocatorMakeMemoryResource(&alloc_tx),
+        .payload  = instrumentedAllocatorMakeMemoryResource(&alloc_tx),
     };
     const UdpardRxMemoryResources mem_rx{
         .session  = instrumentedAllocatorMakeMemoryResource(&alloc_rx_session),
@@ -415,7 +415,7 @@ void testRPC()
     instrumentedAllocatorNew(&alloc_rx_payload);
     const UdpardTxMemoryResources mem_tx{
         .fragment = instrumentedAllocatorMakeMemoryResource(&alloc_tx),
-        .payload = instrumentedAllocatorMakeMemoryResource(&alloc_tx),
+        .payload  = instrumentedAllocatorMakeMemoryResource(&alloc_tx),
     };
     const UdpardRxMemoryResources mem_rx{
         .session  = instrumentedAllocatorMakeMemoryResource(&alloc_rx_session),

--- a/tests/src/test_e2e.cpp
+++ b/tests/src/test_e2e.cpp
@@ -164,7 +164,7 @@ void testPubSub()
     TEST_ASSERT_EQUAL(0, alloc_rx_session.allocated_fragments);
     TEST_ASSERT_EQUAL(0, alloc_rx_fragment.allocated_fragments);
     TEST_ASSERT_EQUAL(0, alloc_rx_payload.allocated_fragments);
-    const UdpardTxItem* tx_item = udpardTxPeek(&tx);
+    UdpardTxItem* tx_item = udpardTxPeek(&tx);
     TEST_ASSERT_NOT_NULL(tx_item);
     TEST_ASSERT_EQUAL(sub.at(1).udp_ip_endpoint.ip_address, tx_item->destination.ip_address);
     TEST_ASSERT_NULL(tx_item->next_in_transfer);
@@ -478,7 +478,7 @@ void testRPC()
     TEST_ASSERT_EQUAL(0, alloc_rx_session.allocated_fragments);
     TEST_ASSERT_EQUAL(0, alloc_rx_fragment.allocated_fragments);
     TEST_ASSERT_EQUAL(0, alloc_rx_payload.allocated_fragments);
-    const UdpardTxItem* tx_item = udpardTxPeek(&tx);
+    UdpardTxItem* tx_item = udpardTxPeek(&tx);
     TEST_ASSERT_NOT_NULL(tx_item);
     TEST_ASSERT_EQUAL(udp_ip_endpoint.ip_address, tx_item->destination.ip_address);
     TEST_ASSERT_NULL(tx_item->next_in_transfer);

--- a/tests/src/test_e2e.cpp
+++ b/tests/src/test_e2e.cpp
@@ -73,7 +73,10 @@ void testPubSub()
     instrumentedAllocatorNew(&alloc_rx_session);
     instrumentedAllocatorNew(&alloc_rx_fragment);
     instrumentedAllocatorNew(&alloc_rx_payload);
-    const auto                    mem_tx = instrumentedAllocatorMakeMemoryResource(&alloc_tx);
+    const UdpardTxMemoryResources mem_tx{
+        .fragment = instrumentedAllocatorMakeMemoryResource(&alloc_tx),
+        .payload = instrumentedAllocatorMakeMemoryResource(&alloc_tx),
+    };
     const UdpardRxMemoryResources mem_rx{
         .session  = instrumentedAllocatorMakeMemoryResource(&alloc_rx_session),
         .fragment = instrumentedAllocatorMakeMemoryResource(&alloc_rx_fragment),
@@ -152,7 +155,7 @@ void testPubSub()
                                       makePayload(Dark),
                                       nullptr));
     TEST_ASSERT_EQUAL(7, tx.queue_size);
-    TEST_ASSERT_EQUAL(7, alloc_tx.allocated_fragments);
+    TEST_ASSERT_EQUAL(7 * 2ULL, alloc_tx.allocated_fragments);
 
     // Transmit the enqueued frames by pushing them into the subscribers.
     // Here we pop the frames one by one ensuring that they come out in the correct order.
@@ -212,7 +215,7 @@ void testPubSub()
     TEST_ASSERT_EQUAL(0, alloc_rx_payload.allocated_fragments);
     // Free the TX item.
     udpardTxFree(mem_tx, udpardTxPop(&tx, tx_item));
-    TEST_ASSERT_EQUAL(6, alloc_tx.allocated_fragments);
+    TEST_ASSERT_EQUAL(6 * 2ULL, alloc_tx.allocated_fragments);
 
     // Second transfer.
     tx_item = udpardTxPeek(&tx);
@@ -247,7 +250,7 @@ void testPubSub()
     TEST_ASSERT_EQUAL(0, alloc_rx_payload.allocated_fragments);
     // Free the TX item.
     udpardTxFree(mem_tx, udpardTxPop(&tx, tx_item));
-    TEST_ASSERT_EQUAL(5, alloc_tx.allocated_fragments);
+    TEST_ASSERT_EQUAL(5 * 2ULL, alloc_tx.allocated_fragments);
 
     // Third transfer. This one is anonymous.
     tx_item = udpardTxPeek(&tx);
@@ -282,7 +285,7 @@ void testPubSub()
     TEST_ASSERT_EQUAL(0, alloc_rx_payload.allocated_fragments);
     // Free the TX item.
     udpardTxFree(mem_tx, udpardTxPop(&tx, tx_item));
-    TEST_ASSERT_EQUAL(4, alloc_tx.allocated_fragments);
+    TEST_ASSERT_EQUAL(4 * 2ULL, alloc_tx.allocated_fragments);
 
     // Fourth transfer. This one contains multiple frames. We process them one-by-one.
     // Frame #0.
@@ -305,7 +308,7 @@ void testPubSub()
     TEST_ASSERT_EQUAL(1, alloc_rx_payload.allocated_fragments);
     // Free the TX item.
     udpardTxFree(mem_tx, udpardTxPop(&tx, tx_item));
-    TEST_ASSERT_EQUAL(3, alloc_tx.allocated_fragments);
+    TEST_ASSERT_EQUAL(3 * 2ULL, alloc_tx.allocated_fragments);
     // Frame #1.
     tx_item = udpardTxPeek(&tx);
     TEST_ASSERT_NOT_NULL(tx_item);
@@ -327,7 +330,7 @@ void testPubSub()
     TEST_ASSERT_EQUAL(2, alloc_rx_payload.allocated_fragments);
     // Free the TX item.
     udpardTxFree(mem_tx, udpardTxPop(&tx, tx_item));
-    TEST_ASSERT_EQUAL(2, alloc_tx.allocated_fragments);
+    TEST_ASSERT_EQUAL(2 * 2ULL, alloc_tx.allocated_fragments);
     // Frame #2.
     tx_item = udpardTxPeek(&tx);
     TEST_ASSERT_NOT_NULL(tx_item);
@@ -349,7 +352,7 @@ void testPubSub()
     TEST_ASSERT_EQUAL(3, alloc_rx_payload.allocated_fragments);
     // Free the TX item.
     udpardTxFree(mem_tx, udpardTxPop(&tx, tx_item));
-    TEST_ASSERT_EQUAL(1, alloc_tx.allocated_fragments);
+    TEST_ASSERT_EQUAL(1 * 2ULL, alloc_tx.allocated_fragments);
     // Frame #3. This is the last frame of the transfer. The payload is truncated, see the extent.
     tx_item = udpardTxPeek(&tx);
     TEST_ASSERT_NOT_NULL(tx_item);
@@ -410,7 +413,10 @@ void testRPC()
     instrumentedAllocatorNew(&alloc_rx_session);
     instrumentedAllocatorNew(&alloc_rx_fragment);
     instrumentedAllocatorNew(&alloc_rx_payload);
-    const auto                    mem_tx = instrumentedAllocatorMakeMemoryResource(&alloc_tx);
+    const UdpardTxMemoryResources mem_tx{
+        .fragment = instrumentedAllocatorMakeMemoryResource(&alloc_tx),
+        .payload = instrumentedAllocatorMakeMemoryResource(&alloc_tx),
+    };
     const UdpardRxMemoryResources mem_rx{
         .session  = instrumentedAllocatorMakeMemoryResource(&alloc_rx_session),
         .fragment = instrumentedAllocatorMakeMemoryResource(&alloc_rx_fragment),
@@ -529,7 +535,7 @@ void testRPC()
     TEST_ASSERT_EQUAL(0, alloc_rx_payload.allocated_fragments);
     // Free the TX item.
     udpardTxFree(mem_tx, udpardTxPop(&tx, tx_item));
-    TEST_ASSERT_EQUAL(1, alloc_tx.allocated_fragments);
+    TEST_ASSERT_EQUAL(1 * 2ULL, alloc_tx.allocated_fragments);
 
     // Second transfer.
     tx_item = udpardTxPeek(&tx);

--- a/tests/src/test_intrusive_tx.c
+++ b/tests/src/test_intrusive_tx.c
@@ -642,7 +642,7 @@ static void testPushPeekPopFree(void)
                       alloc.allocated_bytes);
     TEST_ASSERT_EQUAL(3, tx.queue_size);
 
-    const UdpardTxItem* frame = udpardTxPeek(&tx);
+    UdpardTxItem* frame = udpardTxPeek(&tx);
     TEST_ASSERT_NOT_EQUAL(NULL, frame);
     TEST_ASSERT_NOT_EQUAL(NULL, frame->next_in_transfer);
     TEST_ASSERT_EQUAL(1234567890U, frame->deadline_usec);
@@ -722,7 +722,7 @@ static void testPushPrioritization(void)
                              NULL));
     TEST_ASSERT_EQUAL(3 * 2ULL, alloc.allocated_fragments);
     TEST_ASSERT_EQUAL(3, tx.queue_size);
-    const UdpardTxItem* frame = udpardTxPeek(&tx);
+    UdpardTxItem* frame = udpardTxPeek(&tx);
     TEST_ASSERT_NOT_EQUAL(NULL, frame);
     TEST_ASSERT_EQUAL(0xAAAAAAAA, frame->destination.ip_address);
 

--- a/tests/src/test_intrusive_tx.c
+++ b/tests/src/test_intrusive_tx.c
@@ -96,15 +96,15 @@ static void testMakeChainEmpty(void)
     instrumentedAllocatorNew(&alloc);
     const struct UdpardTxMemoryResources mem = {
         .fragment = instrumentedAllocatorMakeMemoryResource(&alloc),
-        .payload = instrumentedAllocatorMakeMemoryResource(&alloc),
+        .payload  = instrumentedAllocatorMakeMemoryResource(&alloc),
     };
-    char                        user_transfer_referent = '\0';
-    const TransferMetadata      meta                   = {
-                               .priority       = UdpardPriorityFast,
-                               .src_node_id    = 1234,
-                               .dst_node_id    = 2345,
-                               .data_specifier = 5432,
-                               .transfer_id    = 0xBADC0FFEE0DDF00DULL,
+    char                   user_transfer_referent = '\0';
+    const TransferMetadata meta                   = {
+                          .priority       = UdpardPriorityFast,
+                          .src_node_id    = 1234,
+                          .dst_node_id    = 2345,
+                          .data_specifier = 5432,
+                          .transfer_id    = 0xBADC0FFEE0DDF00DULL,
     };
     const TxChain chain = txMakeChain(mem,
                                       (byte_t[]){11, 22, 33, 44, 55, 66, 77, 88},
@@ -143,15 +143,15 @@ static void testMakeChainSingleMaxMTU(void)
     instrumentedAllocatorNew(&alloc);
     const struct UdpardTxMemoryResources mem = {
         .fragment = instrumentedAllocatorMakeMemoryResource(&alloc),
-        .payload = instrumentedAllocatorMakeMemoryResource(&alloc),
+        .payload  = instrumentedAllocatorMakeMemoryResource(&alloc),
     };
-    char                        user_transfer_referent = '\0';
-    const TransferMetadata      meta                   = {
-                               .priority       = UdpardPrioritySlow,
-                               .src_node_id    = 4321,
-                               .dst_node_id    = 5432,
-                               .data_specifier = 7766,
-                               .transfer_id    = 0x0123456789ABCDEFULL,
+    char                   user_transfer_referent = '\0';
+    const TransferMetadata meta                   = {
+                          .priority       = UdpardPrioritySlow,
+                          .src_node_id    = 4321,
+                          .dst_node_id    = 5432,
+                          .data_specifier = 7766,
+                          .transfer_id    = 0x0123456789ABCDEFULL,
     };
     const TxChain chain = txMakeChain(mem,
                                       (byte_t[]){11, 22, 33, 44, 55, 66, 77, 88},
@@ -197,9 +197,9 @@ static void testMakeChainSingleFrameDefaultMTU(void)
     instrumentedAllocatorNew(&alloc);
     const struct UdpardTxMemoryResources mem = {
         .fragment = instrumentedAllocatorMakeMemoryResource(&alloc),
-        .payload = instrumentedAllocatorMakeMemoryResource(&alloc),
+        .payload  = instrumentedAllocatorMakeMemoryResource(&alloc),
     };
-    const byte_t                payload[UDPARD_MTU_DEFAULT_MAX_SINGLE_FRAME + 1] = {0};
+    const byte_t payload[UDPARD_MTU_DEFAULT_MAX_SINGLE_FRAME + 1] = {0};
     {  // Ensure UDPARD_MTU_DEFAULT_MAX_SINGLE_FRAME bytes fit in a single frame with the default MTU.
         const TxChain chain = txMakeChain(mem,
                                           (byte_t[]){11, 22, 33, 44, 55, 66, 77, 88},
@@ -257,15 +257,15 @@ static void testMakeChainThreeFrames(void)
     instrumentedAllocatorNew(&alloc);
     const struct UdpardTxMemoryResources mem = {
         .fragment = instrumentedAllocatorMakeMemoryResource(&alloc),
-        .payload = instrumentedAllocatorMakeMemoryResource(&alloc),
+        .payload  = instrumentedAllocatorMakeMemoryResource(&alloc),
     };
-    char                        user_transfer_referent = '\0';
-    const TransferMetadata      meta                   = {
-                               .priority       = UdpardPriorityNominal,
-                               .src_node_id    = 4321,
-                               .dst_node_id    = 5432,
-                               .data_specifier = 7766,
-                               .transfer_id    = 0x0123456789ABCDEFULL,
+    char                   user_transfer_referent = '\0';
+    const TransferMetadata meta                   = {
+                          .priority       = UdpardPriorityNominal,
+                          .src_node_id    = 4321,
+                          .dst_node_id    = 5432,
+                          .data_specifier = 7766,
+                          .transfer_id    = 0x0123456789ABCDEFULL,
     };
     const size_t  mtu   = (EtherealStrengthSize + 4U + 3U) / 3U;  // Force payload split into three frames.
     const TxChain chain = txMakeChain(mem,
@@ -342,15 +342,15 @@ static void testMakeChainCRCSpill1(void)
     instrumentedAllocatorNew(&alloc);
     const struct UdpardTxMemoryResources mem = {
         .fragment = instrumentedAllocatorMakeMemoryResource(&alloc),
-        .payload = instrumentedAllocatorMakeMemoryResource(&alloc),
+        .payload  = instrumentedAllocatorMakeMemoryResource(&alloc),
     };
-    char                        user_transfer_referent = '\0';
-    const TransferMetadata      meta                   = {
-                               .priority       = UdpardPriorityNominal,
-                               .src_node_id    = 4321,
-                               .dst_node_id    = 5432,
-                               .data_specifier = 7766,
-                               .transfer_id    = 0x0123456789ABCDEFULL,
+    char                   user_transfer_referent = '\0';
+    const TransferMetadata meta                   = {
+                          .priority       = UdpardPriorityNominal,
+                          .src_node_id    = 4321,
+                          .dst_node_id    = 5432,
+                          .data_specifier = 7766,
+                          .transfer_id    = 0x0123456789ABCDEFULL,
     };
     const size_t  mtu   = InterstellarWarSize + 3U;
     const TxChain chain = txMakeChain(mem,
@@ -417,15 +417,15 @@ static void testMakeChainCRCSpill2(void)
     instrumentedAllocatorNew(&alloc);
     const struct UdpardTxMemoryResources mem = {
         .fragment = instrumentedAllocatorMakeMemoryResource(&alloc),
-        .payload = instrumentedAllocatorMakeMemoryResource(&alloc),
+        .payload  = instrumentedAllocatorMakeMemoryResource(&alloc),
     };
-    char                        user_transfer_referent = '\0';
-    const TransferMetadata      meta                   = {
-                               .priority       = UdpardPriorityNominal,
-                               .src_node_id    = 4321,
-                               .dst_node_id    = 5432,
-                               .data_specifier = 7766,
-                               .transfer_id    = 0x0123456789ABCDEFULL,
+    char                   user_transfer_referent = '\0';
+    const TransferMetadata meta                   = {
+                          .priority       = UdpardPriorityNominal,
+                          .src_node_id    = 4321,
+                          .dst_node_id    = 5432,
+                          .data_specifier = 7766,
+                          .transfer_id    = 0x0123456789ABCDEFULL,
     };
     const size_t  mtu   = InterstellarWarSize + 2U;
     const TxChain chain = txMakeChain(mem,
@@ -492,15 +492,15 @@ static void testMakeChainCRCSpill3(void)
     instrumentedAllocatorNew(&alloc);
     const struct UdpardTxMemoryResources mem = {
         .fragment = instrumentedAllocatorMakeMemoryResource(&alloc),
-        .payload = instrumentedAllocatorMakeMemoryResource(&alloc),
+        .payload  = instrumentedAllocatorMakeMemoryResource(&alloc),
     };
-    char                        user_transfer_referent = '\0';
-    const TransferMetadata      meta                   = {
-                               .priority       = UdpardPriorityNominal,
-                               .src_node_id    = 4321,
-                               .dst_node_id    = 5432,
-                               .data_specifier = 7766,
-                               .transfer_id    = 0x0123456789ABCDEFULL,
+    char                   user_transfer_referent = '\0';
+    const TransferMetadata meta                   = {
+                          .priority       = UdpardPriorityNominal,
+                          .src_node_id    = 4321,
+                          .dst_node_id    = 5432,
+                          .data_specifier = 7766,
+                          .transfer_id    = 0x0123456789ABCDEFULL,
     };
     const size_t  mtu   = InterstellarWarSize + 1U;
     const TxChain chain = txMakeChain(mem,
@@ -567,15 +567,15 @@ static void testMakeChainCRCSpillFull(void)
     instrumentedAllocatorNew(&alloc);
     const struct UdpardTxMemoryResources mem = {
         .fragment = instrumentedAllocatorMakeMemoryResource(&alloc),
-        .payload = instrumentedAllocatorMakeMemoryResource(&alloc),
+        .payload  = instrumentedAllocatorMakeMemoryResource(&alloc),
     };
-    char                        user_transfer_referent = '\0';
-    const TransferMetadata      meta                   = {
-                               .priority       = UdpardPriorityNominal,
-                               .src_node_id    = 4321,
-                               .dst_node_id    = 5432,
-                               .data_specifier = 7766,
-                               .transfer_id    = 0x0123456789ABCDEFULL,
+    char                   user_transfer_referent = '\0';
+    const TransferMetadata meta                   = {
+                          .priority       = UdpardPriorityNominal,
+                          .src_node_id    = 4321,
+                          .dst_node_id    = 5432,
+                          .data_specifier = 7766,
+                          .transfer_id    = 0x0123456789ABCDEFULL,
     };
     const size_t  mtu   = InterstellarWarSize;
     const TxChain chain = txMakeChain(mem,
@@ -638,9 +638,9 @@ static void testPushPeekPopFree(void)
     instrumentedAllocatorNew(&alloc);
     const struct UdpardTxMemoryResources mem = {
         .fragment = instrumentedAllocatorMakeMemoryResource(&alloc),
-        .payload = instrumentedAllocatorMakeMemoryResource(&alloc),
+        .payload  = instrumentedAllocatorMakeMemoryResource(&alloc),
     };
-    const UdpardNodeID          node_id = 1234;
+    const UdpardNodeID node_id = 1234;
     //
     UdpardTx tx = {
         .local_node_id           = &node_id,
@@ -720,9 +720,9 @@ static void testPushPrioritization(void)
     instrumentedAllocatorNew(&alloc);
     const struct UdpardTxMemoryResources mem = {
         .fragment = instrumentedAllocatorMakeMemoryResource(&alloc),
-        .payload = instrumentedAllocatorMakeMemoryResource(&alloc),
+        .payload  = instrumentedAllocatorMakeMemoryResource(&alloc),
     };
-    const UdpardNodeID          node_id = 1234;
+    const UdpardNodeID node_id = 1234;
     //
     UdpardTx tx = {
         .local_node_id           = &node_id,
@@ -894,9 +894,9 @@ static void testPushCapacityLimit(void)
     instrumentedAllocatorNew(&alloc);
     const struct UdpardTxMemoryResources mem = {
         .fragment = instrumentedAllocatorMakeMemoryResource(&alloc),
-        .payload = instrumentedAllocatorMakeMemoryResource(&alloc),
+        .payload  = instrumentedAllocatorMakeMemoryResource(&alloc),
     };
-    const UdpardNodeID          node_id = 1234;
+    const UdpardNodeID node_id = 1234;
     //
     UdpardTx tx = {
         .local_node_id           = &node_id,
@@ -932,9 +932,9 @@ static void testPushOOM(void)
     instrumentedAllocatorNew(&alloc);
     const struct UdpardTxMemoryResources mem = {
         .fragment = instrumentedAllocatorMakeMemoryResource(&alloc),
-        .payload = instrumentedAllocatorMakeMemoryResource(&alloc),
+        .payload  = instrumentedAllocatorMakeMemoryResource(&alloc),
     };
-    const UdpardNodeID          node_id = 1234;
+    const UdpardNodeID node_id = 1234;
     //
     UdpardTx tx = {
         .local_node_id           = &node_id,
@@ -971,9 +971,9 @@ static void testPushAnonymousMultiFrame(void)
     instrumentedAllocatorNew(&alloc);
     const struct UdpardTxMemoryResources mem = {
         .fragment = instrumentedAllocatorMakeMemoryResource(&alloc),
-        .payload = instrumentedAllocatorMakeMemoryResource(&alloc),
+        .payload  = instrumentedAllocatorMakeMemoryResource(&alloc),
     };
-    const UdpardNodeID          node_id = 0xFFFFU;
+    const UdpardNodeID node_id = 0xFFFFU;
     //
     UdpardTx tx = {
         .local_node_id           = &node_id,
@@ -1009,9 +1009,9 @@ static void testPushAnonymousService(void)
     instrumentedAllocatorNew(&alloc);
     const struct UdpardTxMemoryResources mem = {
         .fragment = instrumentedAllocatorMakeMemoryResource(&alloc),
-        .payload = instrumentedAllocatorMakeMemoryResource(&alloc),
+        .payload  = instrumentedAllocatorMakeMemoryResource(&alloc),
     };
-    const UdpardNodeID          node_id = 0xFFFFU;
+    const UdpardNodeID node_id = 0xFFFFU;
     //
     UdpardTx tx = {
         .local_node_id           = &node_id,

--- a/tests/src/test_tx.cpp
+++ b/tests/src/test_tx.cpp
@@ -88,9 +88,9 @@ void testPublish()
     instrumentedAllocatorNew(&alloc);
     const UdpardTxMemoryResources mem = {
         .fragment = instrumentedAllocatorMakeMemoryResource(&alloc),
-        .payload = instrumentedAllocatorMakeMemoryResource(&alloc),
+        .payload  = instrumentedAllocatorMakeMemoryResource(&alloc),
     };
-    const UdpardNodeID                node_id = 1234;
+    const UdpardNodeID node_id = 1234;
     //
     UdpardTx tx{
         .local_node_id           = &node_id,
@@ -223,9 +223,9 @@ void testRequest()
     instrumentedAllocatorNew(&alloc);
     const UdpardTxMemoryResources mem = {
         .fragment = instrumentedAllocatorMakeMemoryResource(&alloc),
-        .payload = instrumentedAllocatorMakeMemoryResource(&alloc),
+        .payload  = instrumentedAllocatorMakeMemoryResource(&alloc),
     };
-    const UdpardNodeID         node_id = 1234;
+    const UdpardNodeID node_id = 1234;
     //
     UdpardTx tx{
         .local_node_id           = &node_id,
@@ -376,9 +376,9 @@ void testRespond()
     instrumentedAllocatorNew(&alloc);
     const UdpardTxMemoryResources mem = {
         .fragment = instrumentedAllocatorMakeMemoryResource(&alloc),
-        .payload = instrumentedAllocatorMakeMemoryResource(&alloc),
+        .payload  = instrumentedAllocatorMakeMemoryResource(&alloc),
     };
-    const UdpardNodeID         node_id = 1234;
+    const UdpardNodeID node_id = 1234;
     //
     UdpardTx tx{
         .local_node_id           = &node_id,
@@ -399,7 +399,7 @@ void testRespond()
                                       9876543210,
                                       {.size = FleetingEvents.size(), .data = FleetingEvents.data()},
                                       &user_transfer_referent));
-    TEST_ASSERT_EQUAL(1  * 2ULL, alloc.allocated_fragments);
+    TEST_ASSERT_EQUAL(1 * 2ULL, alloc.allocated_fragments);
     TEST_ASSERT_EQUAL(1, tx.queue_size);
     const auto* frame = udpardTxPeek(&tx);
     std::cout << hexdump::hexdump(frame->datagram_payload.data, frame->datagram_payload.size) << "\n\n";

--- a/tests/src/test_tx.cpp
+++ b/tests/src/test_tx.cpp
@@ -113,7 +113,7 @@ void testPublish()
                                       &user_transfer_referent));
     TEST_ASSERT_EQUAL(1 * 2ULL, alloc.allocated_fragments);
     TEST_ASSERT_EQUAL(1, tx.queue_size);
-    const auto* frame = udpardTxPeek(&tx);
+    auto* frame = udpardTxPeek(&tx);
     std::cout << hexdump::hexdump(frame->datagram_payload.data, frame->datagram_payload.size) << "\n\n";
     TEST_ASSERT_NOT_EQUAL(nullptr, frame);
     TEST_ASSERT_EQUAL(nullptr, frame->next_in_transfer);
@@ -249,7 +249,7 @@ void testRequest()
                                       &user_transfer_referent));
     TEST_ASSERT_EQUAL(1 * 2ULL, alloc.allocated_fragments);
     TEST_ASSERT_EQUAL(1, tx.queue_size);
-    const auto* frame = udpardTxPeek(&tx);
+    auto* frame = udpardTxPeek(&tx);
     std::cout << hexdump::hexdump(frame->datagram_payload.data, frame->datagram_payload.size) << "\n\n";
     TEST_ASSERT_NOT_EQUAL(nullptr, frame);
     TEST_ASSERT_EQUAL(nullptr, frame->next_in_transfer);
@@ -401,7 +401,7 @@ void testRespond()
                                       &user_transfer_referent));
     TEST_ASSERT_EQUAL(1 * 2ULL, alloc.allocated_fragments);
     TEST_ASSERT_EQUAL(1, tx.queue_size);
-    const auto* frame = udpardTxPeek(&tx);
+    auto* frame = udpardTxPeek(&tx);
     std::cout << hexdump::hexdump(frame->datagram_payload.data, frame->datagram_payload.size) << "\n\n";
     TEST_ASSERT_NOT_EQUAL(nullptr, frame);
     TEST_ASSERT_EQUAL(nullptr, frame->next_in_transfer);

--- a/tools/run_sonar.sh
+++ b/tools/run_sonar.sh
@@ -69,7 +69,7 @@ sonar-scanner \
 --define sonar.projectKey=libudpard \
 --define sonar.sources=libudpard \
 --define sonar.exclusions=libudpard/_udpard_cavl.h \
---define sonar.cfamily.build-wrapper-output="$BUILD_DIR" \
+--define sonar.cfamily.compile-commands="$BUILD_DIR/compile_commands.json"
 --define sonar.cfamily.llvm-cov.reportPath="$BUILD_DIR/coverage.txt" \
 --define sonar.cfamily.threads="$(nproc)" \
 || die

--- a/tools/run_sonar.sh
+++ b/tools/run_sonar.sh
@@ -69,7 +69,7 @@ sonar-scanner \
 --define sonar.projectKey=libudpard \
 --define sonar.sources=libudpard \
 --define sonar.exclusions=libudpard/_udpard_cavl.h \
---define sonar.cfamily.compile-commands="$BUILD_DIR/compile_commands.json"
+--define sonar.cfamily.compile-commands="$BUILD_DIR/compile_commands.json" \
 --define sonar.cfamily.llvm-cov.reportPath="$BUILD_DIR/coverage.txt" \
 --define sonar.cfamily.threads="$(nproc)" \
 || die


### PR DESCRIPTION
- `udpardTxPeek` now returns mutable item - needed for payload ownership transfer.
- `udpardTxPop` now accepts mutable item
- eliminated private `TxItem`

Also:
- fixed Sonar warning: property 'sonar.cfamily.build-wrapper-output' is deprecated